### PR TITLE
Bump version to 1.0.3; write changelog entry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ See `client/benchmark.html` for client-side.
 
 ## Changelog
 
+* `1.0.3`
+  - Important bugfixes to UTF-8 encoding (broken in 1.0.2) and the
+    RIPEMD-160 hash (broken in 1.0.1). (gh #6)
+  - New test suite for hashes, CRC32, and hmac; run with 'npm test' in node.
+  - Fixed global variable leaks. (gh #13)
+  - CRC32 will now always return positive values. (gh #11)
 * `1.0.2`
   - Performance improvements and minimal refactor (length property caching, literal notation)
   - Available from Bower package manager
@@ -232,6 +238,7 @@ See `client/benchmark.html` for client-side.
 * Andrew Kepert
 * Ydnar
 * Lostinet
+* [C. Scott Ananian](http://cscott.net)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name" : "jshashes"
 , "description" : "A fast and independent hashing library pure JavaScript implemented (ES5 compliant) for both server and client side (MD5, SHA1, SHA256, SHA512, RIPEMD, HMAC and Base64)"
 , "keywords" : [ "hash", "md5", "sha1", "sha256", "hashes", "sha512", "RIPEMD", "base64", "hmac", "crc", "encoding", "algorithm" ]
-, "version" : "1.0.2"
+, "version" : "1.0.3"
 , "author" : "Tomas Aparicio <tomas@rijndael-project.com>"
 , "maintainers" : [
     {


### PR DESCRIPTION
Thought I'd try to save you some work by writing a changelog entry for the next version.
I took the liberty of adding myself under "Other contributors", hope that's ok.
I'm hoping to see a quick release of 1.0.3 on npm so that I can update my own package and have a fix for gh #6.
Thanks!
