### PR TITLE
Added raw-string methods

### DIFF
--- a/hashes.js
+++ b/hashes.js
@@ -439,6 +439,9 @@
     this.any = function(s, e) { 
       return rstr2any(rstr(s, utf8), e); 
     };
+    this.raw = function (s) {
+        return rstr(s, utf8);
+    };
     this.hex_hmac = function (k, d) { 
       return rstr2hex(rstr_hmac(k, d), hexcase); 
     };
@@ -665,6 +668,9 @@
     this.any = function (s, e) { 
     	return rstr2any(rstr(s, utf8), e);
     };
+    this.raw = function (s) {
+        return rstr(s, utf8);
+    };
     this.hex_hmac = function (k, d) {
     	return rstr2hex(rstr_hmac(k, d));
     };
@@ -845,6 +851,9 @@
     };
     this.any = function (s, e) { 
       return rstr2any(rstr(s, utf8), e); 
+    };
+    this.raw = function (s) {
+        return rstr(s, utf8);
     };
     this.hex_hmac = function (k, d) { 
       return rstr2hex(rstr_hmac(k, d)); 
@@ -1048,6 +1057,9 @@
     };
     this.any = function (s, e) { 
       return rstr2any(rstr(s), e);
+    };
+    this.raw = function (s) {
+        return rstr(s, utf8);
     };
     this.hex_hmac = function (k, d) {
       return rstr2hex(rstr_hmac(k, d));
@@ -1433,6 +1445,9 @@
     };
     this.any = function (s, e) { 
       return rstr2any(rstr(s, utf8), e);
+    };
+    this.raw = function (s) {
+        return rstr(s, utf8);
     };
     this.hex_hmac = function (k, d) { 
       return rstr2hex(rstr_hmac(k, d));


### PR DESCRIPTION
This `raw()` method is analogous to the `digest()` method found in Python’s `hashlib` module; it’s useful for porting algorithms from same. It returns the raw hash data using the per-ciphersuite internal `rstr()` function, encoded as UTF-8 and without applying additional encoding (á la base64).

Here’s an example, in which I used `SHA1.raw()` (called on line 248) to port Django’s cryptographic string-signer to JavaScript: https://bitbucket.org/alexanderbohn/hpf/src/7c13cf8a7dc3e88837e64ce774817f1ca9896afd/instance/hamptons/static/H7/js/duckpunch.js?at=master#cl-242
… the relevant calls to `digest()` in the original Python implementation can be seen here, for the curious: https://github.com/django/django/blob/master/django/core/signing.py#L73-74
